### PR TITLE
Change component configuration map type and use tfvars JSON file

### DIFF
--- a/cli/component/component.go
+++ b/cli/component/component.go
@@ -154,7 +154,7 @@ func (c *DefaultComponent) SetPlatformInfoToComponentConfig() {
 }
 
 // RetrieveComponentConfig returns component config
-func (c *DefaultComponent) RetrieveComponentConfig() map[string]string {
+func (c *DefaultComponent) RetrieveComponentConfig() map[string]interface{} {
 	values, err := c.ComponentConfig.RetrieveConfig(c.PlatformVersion, c.AzureIDorAwsID(), c.ComponentNameAndAllTheDependencies())
 	if err != nil {
 		c.Logger.Fatal().Err(err).Msg("could not deploy")
@@ -205,10 +205,10 @@ func (c *DefaultComponent) AddManagementCredentialsToComponentConfig() {
 }
 
 // LoginToAKSorEKS logs in to AKS or EKS
-func (c *DefaultComponent) LoginToAKSorEKS(componentConfig map[string]string) {
+func (c *DefaultComponent) LoginToAKSorEKS(componentConfig map[string]interface{}) {
 	if c.AwsID != "" {
 		aws := tasks.NewAws(c.GlobalConfig.TmpFolder, c.Logger)
-		if err := aws.LoginToEKS(componentConfig["kubernetes_aws_region"], componentConfig["kubernetes_aws_name"]); err != nil {
+		if err := aws.LoginToEKS(componentConfig["kubernetes_aws_region"].(string), componentConfig["kubernetes_aws_name"].(string)); err != nil {
 			c.Logger.Fatal().Err(err).Msg("could not login to EKS")
 		}
 	}
@@ -222,7 +222,7 @@ func (c *DefaultComponent) LoginToAKSorEKS(componentConfig map[string]string) {
 		if err := az.LoginToAzure(AKSCreds["client_id"].(string), AKSCreds["client_secret"].(string), c.GlobalConfig.TenantID); err != nil {
 			c.Logger.Fatal().Err(err).Msg("could not login to Azure")
 		}
-		clusterName := componentConfig["kubernetes_azure_name"]
+		clusterName := componentConfig["kubernetes_azure_name"].(string)
 		clusterResourceGroup := fmt.Sprintf("kubernetes-%s", clusterName)
 		// Management cluster is different therefore we override this stuff here
 		if clusterName == "management" {

--- a/cli/component/destroy.go
+++ b/cli/component/destroy.go
@@ -1,15 +1,20 @@
 package component
 
-import "github.com/opsteady/opsteady/cli/tasks"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/opsteady/opsteady/cli/tasks"
+)
 
 // Destroy runs the component destruction.
 func (c *DefaultComponent) Destroy() {
 	c.SetCloudCredentialsToEnv()
-	c.SetVaultInfoToComponentConfig()
 	c.SetPlatformInfoToComponentConfig()
 	componentConfig := c.RetrieveComponentConfig()
 
-	executeOrder := c.DeterminOrderOfExecution()
+	executeOrder := c.DetermineOrderOfExecution()
 	if len(c.OverrideDestroyOrder) != 0 {
 		executeOrder = c.OverrideDestroyOrder
 	}
@@ -27,17 +32,30 @@ func (c *DefaultComponent) Destroy() {
 }
 
 // DestroyTerraform destroyes resources created by Terrform
-func (c *DefaultComponent) DestroyTerraform(values map[string]string) {
-	backendStorageName := values["management_bootstrap_terraform_state_account_name"] // Always expecting this to be here
+func (c *DefaultComponent) DestroyTerraform(values map[string]interface{}) {
+	backendStorageName := values["management_bootstrap_terraform_state_account_name"].(string) // Always expecting this to be here
 	terraform := tasks.NewTerraform(c.ComponentFolder, c.TerraformBackendConfigPath, backendStorageName, c.GlobalConfig.CachePath, c.Logger)
 
-	if err := terraform.Destroy(values); err != nil {
+	// Marshall the component configuration to a JSON tfvars file
+	tfvars, err := json.Marshal(values)
+	if err != nil {
+		c.Logger.Fatal().Err(err).Msg("Failed to marshall the component config to tfvars JSON")
+	}
+
+	varsPath := fmt.Sprintf("/tmp/%s.tfvars.json", c.ComponentName)
+
+	err = os.WriteFile(varsPath, tfvars, 0644)
+	if err != nil {
+		c.Logger.Fatal().Err(err).Msg("Failed to create tfvars JSON file")
+	}
+
+	if err := terraform.Destroy(varsPath); err != nil {
 		c.Logger.Fatal().Err(err).Msg("could not apply")
 	}
 }
 
 // DestroyHelm removes Helm charts from Kubernetes
-func (c *DefaultComponent) DestroyHelm(componentConfig map[string]string) {
+func (c *DefaultComponent) DestroyHelm(componentConfig map[string]interface{}) {
 	helm := tasks.NewHelm(c.GlobalConfig.TmpFolder, c.Logger)
 	for _, chart := range c.HelmCharts {
 		if err := helm.Delete(chart.Release, chart.Namespace, c.DryRun); err != nil {

--- a/cli/component/validate.go
+++ b/cli/component/validate.go
@@ -5,7 +5,7 @@ import "github.com/opsteady/opsteady/cli/tasks"
 // Validate validates the Terraform code
 func (c *DefaultComponent) Validate() {
 
-	executeOrder := c.DeterminOrderOfExecution()
+	executeOrder := c.DetermineOrderOfExecution()
 	if len(c.OverrideValidateOrder) != 0 {
 		executeOrder = c.OverrideValidateOrder
 	}

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -122,7 +122,7 @@ func (vc *VaultCredentials) AzureAD() (map[string]interface{}, error) {
 	}
 
 	vc.logger.Debug().Str("id", id).Msg("Requesting AzureAD credentials")
-	secret, err := vc.vault.Read("azuread/creds/default", nil)
+	secret, err := vc.vault.Read("azuread/creds/management", nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve credentials from Vault for %s", id)
 	}

--- a/docs/opsteady/management-setup.md
+++ b/docs/opsteady/management-setup.md
@@ -20,6 +20,8 @@ Note-2: some names used below need to be adjusted as they are globally unique in
 
 You can do the initial setup from your local machine using your own tools but as mentioned in the [ADR](../adr/0011-no-local-tools.md) we want this to be executable without local tools. For that you can create the docker image.
 
+**Note-1: Make sure to replace `dev-management` with whatever container registry name you will be using.**
+
 ```bash
 cd docker/base
 docker build -t dev-management.azurecr.io/base:1.0.0 .
@@ -27,8 +29,6 @@ cd ../cicd
 docker build --build-arg ACR_NAME=dev-management -t dev-management.azurecr.io/cicd:1.0.0 .
 cd ../..
 ```
-
-Note-1: Make sure to replace `dev-management.azurecr.io` with whatever container registry you are using.
 
 ## 02 Bootstrap
 
@@ -41,7 +41,7 @@ docker run -it --rm -v $(pwd):/data dev-management.azurecr.io/cicd:1.0.0 /bin/ba
 
 Before you start, comment the entire `backend "azurerm"` section in `management/bootstrap/terraform.tf`. This will keep the state local temporarily.
 
-When bootstrapping we provide a set of defaults for the Terraform values. They are located in `management/defaults/bootstrap.default.tfvars.json`. You can choose to use this file as-is, or copy it to `management/defaults/bootstrap.tfvars.json` and adjust the values. This custom file will be ignored in the Git repository and is for your use only.
+When bootstrapping we provide a set of defaults for the Terraform values. They are located in `management/defaults/bootstrap.default.tfvars.json`. Copy it to `management/defaults/bootstrap.tfvars.json` and adjust the values. This custom file will be ignored in the Git repository and is for your use only.
 
 Actual steps to perform in the container locally, VSC remote container or on your local machine:
 
@@ -52,10 +52,10 @@ cd management/bootstrap
 terraform init
 terraform providers lock -platform=darwin_amd64 -platform=linux_amd64
 
-terraform apply -var-file=../defaults/bootstrap.default.tfvars.json   # Adjust to ../defaults/bootstrap.tfvars.json if you have a custom variables file
+terraform apply -var-file=../defaults/bootstrap.tfvars.json
 ```
 
-Uncomment the entire `backend "azurerm"` section in `management/bootstrap/terraform.tf` to upload the state to the remote backend. **Make sure to update the `storage_account_name` setting to the name that you used in the previous apply step.**:
+Uncomment the entire `backend "azurerm"` section in `management/bootstrap/terraform.tf` to upload the state to the remote backend.
 
 ```bash
 terraform init -reconfigure -backend-config "storage_account_name=This name should match management_bootstrap_terraform_state_account_name"
@@ -65,8 +65,11 @@ terraform init -reconfigure -backend-config "storage_account_name=This name shou
 
 ## 03 Infra
 
-When creating the initial management infra, we provide a set of defaults for the Terraform values. They are located in `management/defaults/infra.default.tfvars.json`. To deploy the management infrastructure successfully, copy the default file to a custom tfvars file called `management/defaults/infra.tfvars.json`. In this file update the `management_infra_key_vault_ip_rules` to include your IP address in the (now) empty list. This makes sure that when Terraform needs to configure the Key Vault it can do so from your location.
-`
+When creating the initial management infra, we provide a set of defaults for the Terraform values. They are located in `management/defaults/infra.default.tfvars.json`. To deploy the management infrastructure successfully, copy the default file to a custom tfvars file called `management/defaults/infra.tfvars.json`.
+
+In this file update the `management_infra_key_vault_ip_rules` to include your IP address in the (now) empty list. This makes sure that when Terraform needs to configure the Key Vault it can do so from your location.
+In this file also update the `management_infra_key_vault_administrators` to include your AD user object ID. You can find this in the Azure AD. This makes sure that you can administer the key vault.
+In this file also update the `management_infra_platform_admins` to include your AD user object ID. You can find this in the Azure AD. This makes sure that you can login to the Vault later on and manageme the entire platform.
 
 ```bash
 cd management/infra
@@ -105,7 +108,7 @@ Vault is now deployed to the cluster but all the instances are in a sealed state
 
 ```bash
 # Get the admin credentials for the Kubernetes cluster
-az aks get-credentials -g management -n management --admin
+az aks get-credentials -g management -n ${management_infra_aks_name} --admin
 
 # Initialize the Vault cluster
 kubectl exec -n platform -it vault-0 -- vault operator init -ca-path=/vault/userconfig/vault-tls/ca.crt
@@ -128,10 +131,8 @@ terraform providers lock -platform=darwin_amd64 -platform=linux_amd64
 curl -o vault-ca.pem https://${management_vault_infra_storage_account_name}.blob.core.windows.net/vault-ca/ca.pem
 
 # This command will give you some warnings about values for undeclared variables. This is expected and can be ignored.
-terraform apply -compact-warnings -var-file=../../defaults/infra.tfvars.json -var-file=../../defaults/vault-config.tfvars.json -var management_vault_config_token=$VAULT_ROOT_TOKEN_FROM_VAULT_INFRA_RUN
+terraform apply -compact-warnings -var-file=../../defaults/infra.tfvars.json -var-file=../../defaults/vault-config.tfvars.json -var vault_token=$VAULT_ROOT_TOKEN_FROM_VAULT_INFRA_RUN
 ```
-
-NOTE: If you did not add yourself to the "platform-admin" group while creating the management infra then you need to add yourself now via the Azure Portal.
 
 You should now be able to login via OIDC on `https://vault.management.${management_infra_domain}` and see the configurations.
 
@@ -141,6 +142,11 @@ The Vault root token should only be used in emergencies and never in regular Vau
 
 ```
 export VAULT_TOKEN=$ROOT_TOKEN_FROM_VAULT_INIT
+
+# The VAULT_CACERT default location is not yet active, so unset it for this command to succeed.
+# We are providing the ca cert directly from the command line.
+unset VAULT_CACERT
+
 vault token revoke -ca-cert=vault-ca.pem -address=https://vault.management.${management_infra_domain} -self
 ```
 
@@ -175,6 +181,9 @@ docker push ${management_infra_acr_name}.azurecr.io/cicd:1.0.0 .
 Before we can start using the CLI to manage our management environment we need to seed the Vault with our configuration data. For each of the components (management infra, vault infra and vault config) you have created a `$COMPONENT.fvars.json` file that contains the settings for Terraform. This information now needs to be stored in Vault. Please review the contents of the `tfvars.json` files in the `management/defaults` folder and make the adjustments you want (e.g. remove your IP from the key vault whitelist in infra).
 
 ```
+# Make sure that we are in the root of the repository
+cd ../../
+
 # Start the CI/CD container (replace dev-management with your ACR name)
 docker run -it --rm \
   -p 8250:8250 \
@@ -184,9 +193,11 @@ docker run -it --rm \
   dev-management.azurecr.io/cicd:1.0.0 /bin/bash
 
 # Set the Vault address
-export VAULT_ADDR=http://vault.management.${management_infra_domain}
+export VAULT_ADDR=https://vault.management.${management_infra_domain}
 
 # Log into the Vault with OIDC
+# NOTE: make sure that you are part of the platform-admin group for this command to succeed. Also, Vault will not be able
+# to open a browser from the container, so just click/copy the provided link and open it in the browser yourself.
 vault login -method=oidc role=platform-admin listenaddress=0.0.0.0
 
 # Store the component configurations
@@ -206,7 +217,7 @@ cp default-config.yaml config.yaml
 # Open the config.yaml and enter the correct values for your environment
 ```
 
-Now we can run the CLI for all the components and check the Terraform plan. Depending on if you made any changes to the configurations, you will see some changes but mostly it should show no changes.
+Now we can run the CLI for all the components and check the Terraform plan. Depending on if you made any changes to the configurations, you will see some changes but mostly it should show none.
 
 ```
 go run main.go deploy -c management-bootstrap --dry-run --azure-id management --cache

--- a/internal/modules/service-principal/main.tf
+++ b/internal/modules/service-principal/main.tf
@@ -52,7 +52,7 @@ resource "time_rotating" "spn" {
 resource "azuread_service_principal_password" "spn" {
   service_principal_id = azuread_service_principal.spn.id
 
-  keepers = {
+  rotate_when_changed = {
     rotation = time_rotating.spn.id
   }
 }

--- a/management/bootstrap/terraform.tf
+++ b/management/bootstrap/terraform.tf
@@ -18,7 +18,6 @@ terraform {
    */
   backend "azurerm" {
     resource_group_name  = "terraform-state"
-    storage_account_name = "This name should match management_bootstrap_terraform_state_account_name"
     container_name       = "management"
     key                  = "azure/management/management-bootstrap.tfstate"
   }

--- a/management/defaults/bootstrap.default.tfvars.json
+++ b/management/defaults/bootstrap.default.tfvars.json
@@ -1,4 +1,4 @@
 {
   "management_bootstrap_terraform_state_location": "westeurope",
-  "management_bootstrap_terraform_state_account_name": "devmgmtweu"
+  "management_bootstrap_terraform_state_account_name": "opsteadytfos"
 }

--- a/management/defaults/infra.default.tfvars.json
+++ b/management/defaults/infra.default.tfvars.json
@@ -1,5 +1,5 @@
 {
-  "management_infra_acr_name"                             : "devmgmtweu",
+  "management_infra_acr_name"                             : "opsteadyos",
   "management_infra_vnet_address_space"                   : ["10.0.0.0/19"],
   "management_infra_azure_subnet_pods_address_prefixes"   : ["10.0.0.0/20"],
   "management_infra_platform_admins"                      : [],
@@ -13,16 +13,14 @@
   "management_infra_log_analytics_workspace_retention"    : 30,
   "management_infra_azure_subnet_public_address_prefixes" : ["10.0.16.0/24"],
 
-  "management_infra_aks_name"                            : "management",
+  "management_infra_aks_name"                            : "opsteadyos",
   "management_infra_aks_sku_tier"                        : "Free",
   "management_infra_aks_kubernetes_version"              : "1.21.2",
-  "management_infra_aks_system_node_count"               : 2,
-  "management_infra_aks_system_node_size"                : "Standard_B2s",
   "management_infra_aks_api_server_authorized_ip_ranges" : [],
   "management_infra_aks_system_nodepool_node_count"      : 3,
   "management_infra_aks_system_nodepool_node_size"       : "Standard_DS2_v2",
 
-  "management_infra_key_vault_name"           : "management",
+  "management_infra_key_vault_name"           : "opsteadyos",
   "management_infra_key_vault_ip_rules"       : [],
   "management_infra_key_vault_administrators" : []
 }

--- a/management/defaults/vault-infra.default.tfvars
+++ b/management/defaults/vault-infra.default.tfvars
@@ -1,5 +1,5 @@
 {
-  "management_vault_infra_storage_account_name" : "opstdymgmtvault",
+  "management_vault_infra_storage_account_name" : "opsteadyosvault",
   "management_vault_infra_image_repository"     : "vault",
   "management_vault_infra_image_tag"            : "1.8.1",
   "management_vault_infra_chart_version"        : "0.15.0"

--- a/management/infra/acr.tf
+++ b/management/infra/acr.tf
@@ -45,7 +45,7 @@ resource "azurerm_monitor_diagnostic_setting" "acr" {
 
 module "acr_management" {
   source = "../../internal/modules/service-principal"
-  name   = "acr-management"
+  name   = "management-acr"
 }
 
 resource "azurerm_role_assignment" "acr_management" {

--- a/management/infra/aks.tf
+++ b/management/infra/aks.tf
@@ -54,10 +54,51 @@ resource "azurerm_monitor_diagnostic_setting" "aks" {
   log_analytics_workspace_id = azurerm_log_analytics_workspace.management.id
 
   log {
+    category = "cluster-autoscaler"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "guard"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
     category = "kube-apiserver"
     enabled  = true
 
     retention_policy {
+      days = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "kube-audit"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "kube-audit-admin"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
       enabled = false
     }
   }
@@ -67,6 +108,27 @@ resource "azurerm_monitor_diagnostic_setting" "aks" {
     enabled  = true
 
     retention_policy {
+      days = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "kube-scheduler"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
       enabled = false
     }
   }

--- a/management/infra/key_vault.tf
+++ b/management/infra/key_vault.tf
@@ -17,10 +17,7 @@ resource "azurerm_key_vault" "management" {
 }
 
 resource "azurerm_role_assignment" "key_vault_administrator" {
-  for_each = toset(concat([
-    data.azurerm_client_config.current.object_id],
-    var.management_infra_key_vault_administrators
-  ))
+  for_each = toset(var.management_infra_key_vault_administrators)
 
   scope                = azurerm_key_vault.management.id
   role_definition_name = "Key Vault Administrator"

--- a/management/infra/terraform.tf
+++ b/management/infra/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
 
     azuread = {
-      version = "~> 2.2.1"
+      version = "~> 2.5.0"
     }
 
     kubernetes = {
@@ -32,6 +32,11 @@ terraform {
     container_name       = "management"
     key                  = "azure/management/management-infra.tfstate"
   }
+}
+
+provider "azuread" {
+  client_id     = var.azuread_client_id
+  client_secret = var.azuread_client_secret
 }
 
 provider "azurerm" {

--- a/management/infra/variables.tf
+++ b/management/infra/variables.tf
@@ -83,3 +83,13 @@ variable "management_infra_azure_subnet_public_address_prefixes" {
 variable "management_infra_domain" {
   type = string
 }
+
+variable "azuread_client_id" {
+  type = string
+  default = ""
+}
+
+variable "azuread_client_secret" {
+  type = string
+  default = ""
+}

--- a/management/vault/config/cicd/component.go
+++ b/management/vault/config/cicd/component.go
@@ -10,4 +10,9 @@ type ManagementVaultConfig struct {
 // Initialize creates a new managementBootstrap struct
 func (m *ManagementVaultConfig) Initialize(defaultComponent component.DefaultComponent) {
 	m.DefaultComponent = defaultComponent
+	m.DefaultComponent.Terraform = "" // Use root of the folder
+
+	m.DefaultComponent.SetVaultInfoToComponentConfig()
+	m.DefaultComponent.AddAzureADCredentialsToComponentConfig()
+	m.DefaultComponent.RequiresComponents("management-infra")
 }

--- a/management/vault/config/policies/platform-admin.hcl
+++ b/management/vault/config/policies/platform-admin.hcl
@@ -81,6 +81,11 @@ path "aws/*"
   capabilities = ["read", "create", "update", "delete", "list", "sudo"]
 }
 
+path "azuread/*"
+{
+  capabilities = ["read", "create", "update", "delete", "list", "sudo"]
+}
+
 path "azure/*"
 {
   capabilities = ["read", "create", "update", "delete", "list", "sudo"]

--- a/management/vault/config/terraform.tf
+++ b/management/vault/config/terraform.tf
@@ -12,7 +12,7 @@ terraform {
     }
 
     azuread = {
-      version = "~> 2.2.1"
+      version = "~> 2.5.0"
     }
 
     aws = {
@@ -44,7 +44,7 @@ provider "azuread" {
 
 provider "vault" {
   address      = "https://vault.management.${var.management_infra_domain}"
-  token        = var.management_vault_config_token
+  token        = var.vault_token
   ca_cert_file = var.management_vault_config_ca_cert_file
 }
 

--- a/management/vault/config/variables.tf
+++ b/management/vault/config/variables.tf
@@ -2,7 +2,7 @@ variable "management_infra_domain" {
   type = string
 }
 
-variable "management_vault_config_token" {
+variable "vault_token" {
   type = string
 }
 

--- a/management/vault/infra/cicd/component.go
+++ b/management/vault/infra/cicd/component.go
@@ -10,4 +10,7 @@ type ManagementVaultInfra struct {
 // Initialize creates a new managementBootstrap struct
 func (m *ManagementVaultInfra) Initialize(defaultComponent component.DefaultComponent) {
 	m.DefaultComponent = defaultComponent
+	m.DefaultComponent.Terraform = "" // Use root of the folder
+	m.DefaultComponent.AddAzureADCredentialsToComponentConfig()
+	m.DefaultComponent.RequiresComponents("management-infra")
 }

--- a/management/vault/infra/dns.tf
+++ b/management/vault/infra/dns.tf
@@ -6,11 +6,11 @@ resource "azurerm_dns_a_record" "vault" {
   records             = [azurerm_public_ip.vault.ip_address]
 }
 
-# This resource lives in the nodes-management resource group to ensure that
+# This resource lives in the nodes resource group to ensure that
 # the dynamically created loadbalancer can use the IP address.
 resource "azurerm_public_ip" "vault" {
   name                = "vault"
-  resource_group_name = "nodes-management"
+  resource_group_name = "nodes-${var.management_infra_aks_name}"
   location            = var.management_infra_location
   allocation_method   = "Static"
   sku                 = "Standard"

--- a/management/vault/infra/terraform.tf
+++ b/management/vault/infra/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
 
     azuread = {
-      version = "~> 2.3.0"
+      version = "~> 2.5.0"
     }
 
     kubernetes = {
@@ -32,6 +32,11 @@ terraform {
 
 provider "azurerm" {
   features {}
+}
+
+provider "azuread" {
+  client_id     = var.azuread_client_id
+  client_secret = var.azuread_client_secret
 }
 
 provider "kubernetes" {

--- a/management/vault/infra/variables.tf
+++ b/management/vault/infra/variables.tf
@@ -29,3 +29,13 @@ variable "management_vault_infra_image_tag" {
 variable "management_vault_infra_chart_version" {
   type = string
 }
+
+variable "azuread_client_id" {
+  type = string
+  default = ""
+}
+
+variable "azuread_client_secret" {
+  type = string
+  default = ""
+}

--- a/management/vault/infra/vault.tf
+++ b/management/vault/infra/vault.tf
@@ -1,6 +1,6 @@
 module "vault_unseal" {
   source = "../../../internal/modules/service-principal"
-  name   = "vault-unseal-new"
+  name   = "vault-unseal"
 }
 
 # Vault auto-unseal key


### PR DESCRIPTION
This PR changes the map type for the component configuration from map[string]string to map[string]interface{]. For the Terraform tasks it converts this map to a tfvars JSON file that Terraform can use as input for the variables.